### PR TITLE
Fix/Explicitly require parquet engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyXLMS"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
   { name="Micha Johannes Birklbauer", email="micha.birklbauer@fh-hagenberg.at" },
 ]
@@ -33,7 +33,8 @@ dependencies = [
   "biopython",
   "biopandas",
   "matplotlib",
-  "matplotlib-venn"
+  "matplotlib-venn",
+  "pyarrow"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib
 matplotlib-venn
 streamlit
 xlsxwriter
+pyarrow

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -15,7 +15,7 @@ project = "pyXLMS"
 copyright = "2025, Micha Johannes Birklbauer"
 author = "Micha Johannes Birklbauer"
 version = "1.5"
-release = "1.5.0"
+release = "1.5.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/pyXLMS/__init__.py
+++ b/src/pyXLMS/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "transform",
     "plotting",
 ]
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __author__ = "Micha Johannes Birklbauer"
 
 from . import constants


### PR DESCRIPTION
- Explicitly require parquet engine for reading parquet files
- Add `pyarrow` as dependency
