### PR TITLE
Feat/Add Residue Pair Distribution Filter & Plot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyXLMS"
-version = "1.8.4"
+version = "1.8.5"
 authors = [
   { name="Micha Johannes Birklbauer", email="micha.birklbauer@fh-hagenberg.at" },
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -15,7 +15,7 @@ project = "pyXLMS"
 copyright = "2025, Bioinformatics Research Group, FH Oberösterreich Campus Hagenberg"
 author = "Micha Johannes Birklbauer"
 version = "1.8"
-release = "1.8.4"
+release = "1.8.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/pyXLMS/__init__.py
+++ b/src/pyXLMS/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "transform",
     "plotting",
 ]
-__version__ = "1.8.4"
+__version__ = "1.8.5"
 __author__ = "Micha Johannes Birklbauer"
 
 from . import constants

--- a/src/pyXLMS/plotting/__init__.py
+++ b/src/pyXLMS/plotting/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "plot_protein_distribution",
     "plot_peptide_pair_distribution",
     "plot_crosslink_type_distribution",
+    "plot_residue_pair_distribution",
 ]
 
 from .plot_venn_diagram import venn
@@ -21,3 +22,4 @@ from .plot_target_decoy_distribution import plot_target_decoy_distribution
 from .plot_protein_distribution import plot_protein_distribution
 from .plot_peptide_pair_distribution import plot_peptide_pair_distribution
 from .plot_crosslink_type_distribution import plot_crosslink_type_distribution
+from .plot_residue_pair_distribution import plot_residue_pair_distribution

--- a/src/pyXLMS/plotting/plot_residue_pair_distribution.py
+++ b/src/pyXLMS/plotting/plot_residue_pair_distribution.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+# 2026 (c) Micha Johannes Birklbauer
+# https://github.com/michabirklbauer/
+# micha.birklbauer@gmail.com
+
+from __future__ import annotations
+
+import pandas as pd
+from matplotlib import pyplot as plt
+from matplotlib.figure import Figure
+
+from ..data import check_input
+from ..transform.filter import filter_residue_pair_distribution
+
+from typing import Optional
+from typing import List
+from typing import Dict
+from typing import Tuple
+from typing import Any
+
+
+def plot_residue_pair_distribution(
+    data: List[Dict[str, Any]],
+    top_n: int = 25,
+    color: str = "#6d4bff",
+    title: str = "Residue Pair Distribution",
+    figsize: Tuple[float, float] = (16.0, 9.0),
+    filename_prefix: Optional[str] = None,
+) -> Tuple[Figure, Any]:
+    r"""Plot the residue pair distribution for a set of crosslink-spectrum-matches.
+
+    Plot the residue pair distribution as a barplot for a set of crosslink-spectrum-matches.
+    Requires that ``alpha_proteins``, ``beta_proteins``, ``alpha_proteins_crosslink_positions``, and
+    ``beta_proteins_crosslink_positions`` fields are set for all crosslink-spectrum-matches.
+
+    Parameters
+    ----------
+    data : list of dict of str, any
+        A list of crosslink-spectrum-matches.
+    top_n : int, default = 25
+        Number of residue pairs to plot. Residue pairs are sorted by number of
+        crosslink-spectrum-matches.
+    color : str, default = "#6d4bff"
+        Color of the bars.
+    title : str, default = "Residue Pair Distribution"
+        The title of the barplot.
+    figsize : tuple of float, float, default = (16.0, 9.0)
+        Width, height in inches.
+    filename_prefix : str, or None
+        If given, plot will be saved with and without title in .png and .svg format with the given
+        prefix.
+
+    Returns
+    -------
+    tuple of matplotlib.figure.Figure, any
+        The created figure and axis ``from matplotlib.pyplot.subplots()``.
+
+    Raises
+    ------
+    TypeError
+        If a wrong data type is provided.
+    ValueError
+        If parameter data does not contain any crosslink-spectrum-matches.
+
+    Examples
+    --------
+    >>> from pyXLMS import parser
+    >>> from pyXLMS import plotting
+    >>> pr = parser.read_msannika(
+    ...     "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx"
+    ... )
+    >>> csms = pr["crosslink-spectrum-matches"]
+    >>> fig, ax = plotting.plot_residue_pair_distribution(csms)
+    """
+    _ok = check_input(data, "data", list, dict)
+    _ok = check_input(top_n, "top_n", int)
+    _ok = check_input(color, "color", str)
+    _ok = check_input(title, "title", str)
+    _ok = check_input(figsize, "figsize", tuple)
+    _ok = (
+        check_input(filename_prefix, "filename_prefix", str)
+        if filename_prefix is not None
+        else True
+    )
+    if len(data) == 0:
+        raise ValueError(
+            "Can't plot residue pair distribution if no crosslink-spectrum-matches are given!"
+        )
+    if "data_type" not in data[0] or data[0]["data_type"] != "crosslink-spectrum-match":
+        raise TypeError(
+            "Unsupported data type for input data! Parameter data has to be a list of crosslink-spectrum-match!"
+        )
+    rps = filter_residue_pair_distribution(data)
+    rp_names = list()
+    rp_total = list()
+    for rp in rps:
+        rp_names.append(rp)
+        rp_total.append(len(rps[rp]))
+
+    sorted = pd.DataFrame(
+        {
+            "residue_pair": rp_names,
+            "total": rp_total,
+        }
+    ).sort_values(by="total", axis=0, ascending=False)
+    rp_names = sorted["residue_pair"].values.tolist()[:top_n]
+    rp_total = sorted["total"].values.tolist()[:top_n]
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    bar = ax.bar(rp_names, rp_total, color=color)
+    ax.bar_label(bar, padding=3.0)
+
+    ax.set_xticks(range(len(rp_names)), rp_names, rotation=45, ha="right")
+    ax.set_ylabel("Number of crosslink-spectrum-matches")
+    ax.set_xlabel("Residue Pair")
+
+    if filename_prefix is not None:
+        plt.savefig(
+            filename_prefix + "_notitle.png",
+            dpi=300,
+            transparent=True,
+            bbox_inches="tight",
+        )
+        plt.savefig(
+            filename_prefix + "_notitle.svg",
+            dpi=300,
+            transparent=True,
+            bbox_inches="tight",
+        )
+        ax.set_title(title)
+        plt.savefig(
+            filename_prefix + ".png", dpi=300, transparent=True, bbox_inches="tight"
+        )
+        plt.savefig(
+            filename_prefix + ".svg", dpi=300, transparent=True, bbox_inches="tight"
+        )
+    else:
+        ax.set_title(title)
+
+    return (fig, ax)

--- a/src/pyXLMS/transform/__init__.py
+++ b/src/pyXLMS/transform/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "intersection",
     "annotate_fdr",
     "reannotate_decoy_labels",
+    "filter_residue_pair_distribution",
 ]
 
 from .util import modifications_to_str
@@ -49,3 +50,4 @@ from .reannotate_positions import reannotate_positions
 from .intersection import intersection
 from .annotate_fdr import annotate_fdr
 from .reannotate_decoy_labels import reannotate_decoy_labels
+from .filter import filter_residue_pair_distribution

--- a/src/pyXLMS/transform/filter.py
+++ b/src/pyXLMS/transform/filter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from ..data import check_input
 from ..data import check_input_multi
+from .util import get_available_keys
 
 from typing import Dict
 from typing import List
@@ -397,3 +398,99 @@ def filter_peptide_pair_distribution(
         else:
             peptide_pairs[peptide_pair] = [item]
     return peptide_pairs
+
+
+def filter_residue_pair_distribution(
+    data: List[Dict[str, Any]],
+    prefix_decoys: bool = True,
+) -> Dict[str, List[Dict[str, Any]]]:
+    r"""Get all crosslink-spectrum-matches sorted by their protein residue pair.
+
+    Sorts all crosslink-spectrum-matches into a dictionary that maps protein residue pairs denoted as their
+    protein accessions plus their protein crosslink positions delimited by a hyphen (e.g. "Cas9:48-Cas9:677")
+    to their associated crosslink-spectrum-matches. If a peptide matches to more than one protein, the residues
+    are delimited by commas (e.g. "Cas9:48,ALBU:36-Cas9:677"). Requires that ``alpha_proteins``, ``beta_proteins``,
+    ``alpha_proteins_crosslink_positions``, and ``beta_proteins_crosslink_positions`` fields are set for all
+    crosslink-spectrum-matches.
+
+    Parameters
+    ----------
+    data : list of dict of str, any
+        A list of pyXLMS crosslink-spectrum-matches.
+    prefix_decoys : bool, default = True
+        Whether decoy residues/proteins should be prefixed with a "DECOY_" string.
+
+    Returns
+    -------
+    dict of str, list of dict
+        Returns a dictionary that maps protein residue pairs denoted as their protein accessions plus their protein
+        crosslink positions delimited by a hyphen to their associated crosslink-spectrum-matches. If a peptide matches
+        to more than one protein, the residues are delimited by commas.
+
+    Raises
+    ------
+    TypeError
+        If an unsupported data type is provided.
+    RuntimeError
+        If any of the crosslink-spectrum-matches do not have associated proteins or protein crosslink positions.
+
+    Examples
+    --------
+    >>> from pyXLMS.parser import read
+    >>> from pyXLMS.transform import filter_residue_pair_distribution
+    >>> result = read(
+    ...     "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+    ...     engine="MS Annika",
+    ...     crosslinker="DSS",
+    ... )
+    >>> residue_pairs = filter_residue_pair_distribution(
+    ...     result["crosslink-spectrum-matches"]
+    ... )
+    >>> list(residue_pairs.keys())[:5]  # first 5 found residue pairs
+    ['Cas9:779-Cas9:779', 'Cas9:779-DECOY_Cas9:696', 'Cas9:866-Cas9:866', 'Cas9:677-Cas9:677', 'Cas9:48-Cas9:677']
+    >>> len(
+    ...     residue_pairs["Cas9:1122-Cas9:884"]
+    ... )  # number of CSMs for residue pair Cas9:1122-Cas9:884
+    22
+    """
+    _ok = check_input(data, "data", list, dict)
+    available_keys = get_available_keys(data)
+    if (
+        not available_keys["alpha_proteins"]
+        or not available_keys["beta_proteins"]
+        or not available_keys["alpha_proteins_crosslink_positions"]
+        or not available_keys["beta_proteins_crosslink_positions"]
+    ):
+        raise RuntimeError(
+            "Can't filter by residue pair because not all necessary information is available!"
+        )
+    residue_pairs = dict()
+    for item in data:
+        if "data_type" not in item or item["data_type"] != "crosslink-spectrum-match":
+            raise TypeError(
+                "Unsupported data type for input data! Parameter data has to be a list of crosslink-spectrum-match!"
+            )
+        alpha_residue = "DECOY_" if prefix_decoys and item["alpha_decoy"] else ""
+        alpha_residue += ",".join(
+            sorted(
+                [
+                    f"{item['alpha_proteins'][i]}:{item['alpha_proteins_crosslink_positions'][i]}"
+                    for i in range(len(item["alpha_proteins"]))
+                ]
+            )
+        )
+        beta_residue = "DECOY_" if prefix_decoys and item["beta_decoy"] else ""
+        beta_residue += ",".join(
+            sorted(
+                [
+                    f"{item['beta_proteins'][i]}:{item['beta_proteins_crosslink_positions'][i]}"
+                    for i in range(len(item["beta_proteins"]))
+                ]
+            )
+        )
+        residue_pair = "-".join(sorted([alpha_residue, beta_residue]))
+        if residue_pair in residue_pairs:
+            residue_pairs[residue_pair].append(item)
+        else:
+            residue_pairs[residue_pair] = [item]
+    return residue_pairs

--- a/src/pyXLMS/transform/filter.py
+++ b/src/pyXLMS/transform/filter.py
@@ -342,7 +342,7 @@ def filter_peptide_pair_distribution(
     r"""Get all crosslink-spectrum-matches sorted by their peptide pair.
 
     Sorts all crosslink-spectrum-matches into a dictionary that maps peptide pairs denoted as their
-    amino acid sequences plus their crosslink positions delimited by a hyphen (e.g. "MTNFDKNLPNEK6-SKLVSDFR2")
+    amino acid sequences plus their crosslink positions delimited by a hyphen (e.g. "MTNFDKNLPNEK:6-SKLVSDFR:2")
     to their associated crosslink-spectrum-matches.
 
     Parameters
@@ -376,10 +376,10 @@ def filter_peptide_pair_distribution(
     ...     result["crosslink-spectrum-matches"]
     ... )
     >>> list(peptide_pairs.keys())[:5]  # first 5 found peptide pairs
-    ['GQKNSR3-GQKNSR3', 'GQKNSR3-DECOY_GSQKDR4', 'SDKNR3-SDKNR3', 'DKQSGK2-DKQSGK2', 'DKQSGK2-HSIKK4']
+    ['GQKNSR:3-GQKNSR:3', 'GQKNSR:3-DECOY_GSQKDR:4', 'SDKNR:3-SDKNR:3', 'DKQSGK:2-DKQSGK:2', 'DKQSGK:2-HSIKK:4']
     >>> len(
-    ...     peptide_pairs["MTNFDKNLPNEK6-SKLVSDFR2"]
-    ... )  # number of CSMs for peptide pair MTNFDKNLPNEK6-SKLVSDFR2
+    ...     peptide_pairs["MTNFDKNLPNEK:6-SKLVSDFR:2"]
+    ... )  # number of CSMs for peptide pair MTNFDKNLPNEK:6-SKLVSDFR:2
     21
     """
     _ok = check_input(data, "data", list, dict)
@@ -390,8 +390,8 @@ def filter_peptide_pair_distribution(
                 "Unsupported data type for input data! Parameter data has to be a list of crosslink-spectrum-match!"
             )
         peptide_pair = (
-            f"{'DECOY_' if prefix_decoys and item['alpha_decoy'] else ''}{item['alpha_peptide']}{item['alpha_peptide_crosslink_position']}-"
-            f"{'DECOY_' if prefix_decoys and item['beta_decoy'] else ''}{item['beta_peptide']}{item['beta_peptide_crosslink_position']}"
+            f"{'DECOY_' if prefix_decoys and item['alpha_decoy'] else ''}{item['alpha_peptide']}:{item['alpha_peptide_crosslink_position']}-"
+            f"{'DECOY_' if prefix_decoys and item['beta_decoy'] else ''}{item['beta_peptide']}:{item['beta_peptide_crosslink_position']}"
         )
         if peptide_pair in peptide_pairs:
             peptide_pairs[peptide_pair].append(item)

--- a/src/pyXLMS/transform/filter.py
+++ b/src/pyXLMS/transform/filter.py
@@ -336,6 +336,7 @@ def filter_crosslink_type(data: List[Dict[str, Any]]) -> Dict[str, List[Any]]:
 
 def filter_peptide_pair_distribution(
     data: List[Dict[str, Any]],
+    prefix_decoys: bool = True,
 ) -> Dict[str, List[Dict[str, Any]]]:
     r"""Get all crosslink-spectrum-matches sorted by their peptide pair.
 
@@ -347,6 +348,8 @@ def filter_peptide_pair_distribution(
     ----------
     data : list of dict of str, any
         A list of pyXLMS crosslink-spectrum-matches.
+    prefix_decoys : bool, default = True
+        Whether decoy peptides should be prefixed with a "DECOY_" string.
 
     Returns
     -------
@@ -372,7 +375,7 @@ def filter_peptide_pair_distribution(
     ...     result["crosslink-spectrum-matches"]
     ... )
     >>> list(peptide_pairs.keys())[:5]  # first 5 found peptide pairs
-    ['GQKNSR3-GQKNSR3', 'GQKNSR3-GSQKDR4', 'SDKNR3-SDKNR3', 'DKQSGK2-DKQSGK2', 'DKQSGK2-HSIKK4']
+    ['GQKNSR3-GQKNSR3', 'GQKNSR3-DECOY_GSQKDR4', 'SDKNR3-SDKNR3', 'DKQSGK2-DKQSGK2', 'DKQSGK2-HSIKK4']
     >>> len(
     ...     peptide_pairs["MTNFDKNLPNEK6-SKLVSDFR2"]
     ... )  # number of CSMs for peptide pair MTNFDKNLPNEK6-SKLVSDFR2
@@ -385,7 +388,10 @@ def filter_peptide_pair_distribution(
             raise TypeError(
                 "Unsupported data type for input data! Parameter data has to be a list of crosslink-spectrum-match!"
             )
-        peptide_pair = f"{item['alpha_peptide']}{item['alpha_peptide_crosslink_position']}-{item['beta_peptide']}{item['beta_peptide_crosslink_position']}"
+        peptide_pair = (
+            f"{'DECOY_' if prefix_decoys and item['alpha_decoy'] else ''}{item['alpha_peptide']}{item['alpha_peptide_crosslink_position']}-"
+            f"{'DECOY_' if prefix_decoys and item['beta_decoy'] else ''}{item['beta_peptide']}{item['beta_peptide_crosslink_position']}"
+        )
         if peptide_pair in peptide_pairs:
             peptide_pairs[peptide_pair].append(item)
         else:

--- a/src/pyXLMS/transform/filter.py
+++ b/src/pyXLMS/transform/filter.py
@@ -409,9 +409,9 @@ def filter_residue_pair_distribution(
     Sorts all crosslink-spectrum-matches into a dictionary that maps protein residue pairs denoted as their
     protein accessions plus their protein crosslink positions delimited by a hyphen (e.g. "Cas9:48-Cas9:677")
     to their associated crosslink-spectrum-matches. If a peptide matches to more than one protein, the residues
-    are delimited by commas (e.g. "Cas9:48,ALBU:36-Cas9:677"). Requires that ``alpha_proteins``, ``beta_proteins``,
-    ``alpha_proteins_crosslink_positions``, and ``beta_proteins_crosslink_positions`` fields are set for all
-    crosslink-spectrum-matches.
+    are delimited by commas (e.g. "Cas9:48,ALBU:36-Cas9:677").
+    Requires that ``alpha_proteins``, ``beta_proteins``, ``alpha_proteins_crosslink_positions``, and
+    ``beta_proteins_crosslink_positions`` fields are set for all crosslink-spectrum-matches.
 
     Parameters
     ----------

--- a/src/pyXLMS/transform/filter.py
+++ b/src/pyXLMS/transform/filter.py
@@ -340,8 +340,8 @@ def filter_peptide_pair_distribution(
     r"""Get all crosslink-spectrum-matches sorted by their peptide pair.
 
     Sorts all crosslink-spectrum-matches into a dictionary that maps peptide pairs denoted as their
-    amino acid sequences delimited by a hyphen (e.g. "MTNFDKNLPNEK-SKLVSDFR") to their associated
-    crosslink-spectrum-matches.
+    amino acid sequences plus their crosslink positions delimited by a hyphen (e.g. "MTNFDKNLPNEK6-SKLVSDFR2")
+    to their associated crosslink-spectrum-matches.
 
     Parameters
     ----------
@@ -351,8 +351,8 @@ def filter_peptide_pair_distribution(
     Returns
     -------
     dict of str, list of dict
-        Returns a dictionary that maps peptide pairs denoted as their amino acid sequences delimited by a
-        hyphen to their associated crosslink-spectrum-matches.
+        Returns a dictionary that maps peptide pairs denoted as their amino acid sequences plus their
+        crosslink positions delimited by a hyphen to their associated crosslink-spectrum-matches.
 
     Raises
     ------
@@ -372,10 +372,10 @@ def filter_peptide_pair_distribution(
     ...     result["crosslink-spectrum-matches"]
     ... )
     >>> list(peptide_pairs.keys())[:5]  # first 5 found peptide pairs
-    ['GQKNSR-GQKNSR', 'GQKNSR-GSQKDR', 'SDKNR-SDKNR', 'DKQSGK-DKQSGK', 'DKQSGK-HSIKK']
+    ['GQKNSR3-GQKNSR3', 'GQKNSR3-GSQKDR4', 'SDKNR3-SDKNR3', 'DKQSGK2-DKQSGK2', 'DKQSGK2-HSIKK4']
     >>> len(
-    ...     peptide_pairs["MTNFDKNLPNEK-SKLVSDFR"]
-    ... )  # number of CSMs for peptide pair MTNFDKNLPNEK-SKLVSDFR
+    ...     peptide_pairs["MTNFDKNLPNEK6-SKLVSDFR2"]
+    ... )  # number of CSMs for peptide pair MTNFDKNLPNEK6-SKLVSDFR2
     21
     """
     _ok = check_input(data, "data", list, dict)
@@ -385,7 +385,7 @@ def filter_peptide_pair_distribution(
             raise TypeError(
                 "Unsupported data type for input data! Parameter data has to be a list of crosslink-spectrum-match!"
             )
-        peptide_pair = f"{item['alpha_peptide']}-{item['beta_peptide']}"
+        peptide_pair = f"{item['alpha_peptide']}{item['alpha_peptide_crosslink_position']}-{item['beta_peptide']}{item['beta_peptide_crosslink_position']}"
         if peptide_pair in peptide_pairs:
             peptide_pairs[peptide_pair].append(item)
         else:

--- a/src/pyXLMS/transform/util.py
+++ b/src/pyXLMS/transform/util.py
@@ -97,7 +97,9 @@ def assert_data_type_same(data_list: List[Dict[str, Any]]) -> bool:
     return True
 
 
-def get_available_keys(data_list: List[Dict[str, Any]]) -> Dict[str, bool]:
+def get_available_keys(
+    data_list: List[Dict[str, Any]], always_revalidate: bool = True
+) -> Dict[str, bool]:
     r"""Checks which data is available from a list of crosslinks or crosslink-spectrum-matches.
 
     Verifies which data fields have been set for all crosslinks or crosslink-spectrum-matches in the
@@ -108,6 +110,9 @@ def get_available_keys(data_list: List[Dict[str, Any]]) -> Dict[str, bool]:
     ----------
     data_list : list of dict of str, any
         A list of crosslinks or crosslink-spectrum-matches.
+    always_revalidate : bool, default = True
+        If ``True`` (default) the assigned ``completeness`` will be ignored and all data fields
+        are re-checked. This is safer especially when data has been modified post reading.
 
     Returns
     -------
@@ -170,7 +175,7 @@ def get_available_keys(data_list: List[Dict[str, Any]]) -> Dict[str, bool]:
     # parse available keys
     if data_type == "crosslink":
         for data in data_list:
-            if data["completeness"] != "full":
+            if data["completeness"] != "full" or always_revalidate:
                 if data["alpha_proteins"] is None:
                     proteins_a = False
                 if data["alpha_proteins_crosslink_positions"] is None:
@@ -206,7 +211,7 @@ def get_available_keys(data_list: List[Dict[str, Any]]) -> Dict[str, bool]:
         }
     if data_type == "crosslink-spectrum-match":
         for data in data_list:
-            if data["completeness"] != "full":
+            if data["completeness"] != "full" or always_revalidate:
                 if data["alpha_modifications"] is None:
                     modifications_a = False
                 if data["alpha_proteins"] is None:

--- a/tests/test_plotting_plot_residue_pair_distribution.py
+++ b/tests/test_plotting_plot_residue_pair_distribution.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+# pyXLMS - TESTS
+# 2026 (c) Micha Johannes Birklbauer
+# https://github.com/michabirklbauer/
+# micha.birklbauer@gmail.com
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def cleanup_figures():
+    from matplotlib import use
+    import matplotlib.pyplot as plt
+
+    use("agg")
+
+    yield
+
+    plt.close(fig="all")
+
+
+@pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
+def test1():
+    from pyXLMS import parser
+    from pyXLMS import plotting
+
+    pr = parser.read_msannika(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx"
+    )
+    csms = pr["crosslink-spectrum-matches"]
+    fig, ax = plotting.plot_residue_pair_distribution(csms)
+    assert fig is not None
+    assert ax is not None
+
+
+@pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
+def test2():
+    from pyXLMS import parser
+    from pyXLMS import plotting
+
+    pr = parser.read_msannika(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx"
+    )
+    csms = pr["crosslink-spectrum-matches"]
+    fig, ax = plotting.plot_residue_pair_distribution(csms, top_n=2)
+    assert fig is not None
+    assert ax is not None
+
+
+@pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
+def test3():
+    from pyXLMS import parser
+    from pyXLMS import plotting
+
+    pr = parser.read_msannika(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx"
+    )
+    csms = pr["crosslink-spectrum-matches"]
+    fig, ax = plotting.plot_residue_pair_distribution(csms, top_n=10000)
+    assert fig is not None
+    assert ax is not None
+
+
+def test4():
+    from pyXLMS.plotting import plot_residue_pair_distribution
+
+    with pytest.raises(
+        ValueError,
+        match=r"Can't plot residue pair distribution if no crosslink-spectrum-matches are given!",
+    ):
+        _plot = plot_residue_pair_distribution([])
+
+
+def test5():
+    from pyXLMS.parser import read
+    from pyXLMS.plotting import plot_residue_pair_distribution
+
+    pr = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+
+    pr["crosslink-spectrum-matches"][0]["data_type"] = "peptide-spectrum-match"
+
+    with pytest.raises(
+        TypeError,
+        match=r"Unsupported data type for input data! Parameter data has to be a list of crosslink-spectrum-match!",
+    ):
+        _plot = plot_residue_pair_distribution(pr["crosslink-spectrum-matches"])

--- a/tests/test_transform_filter.py
+++ b/tests/test_transform_filter.py
@@ -128,7 +128,7 @@ def test8():
         crosslinker="DSS",
     )
     peptide_pairs = filter_peptide_pair_distribution(
-        result["crosslink-spectrum-matches"]
+        result["crosslink-spectrum-matches"], prefix_decoys=False
     )
     peptide_pairs_found = list(peptide_pairs.keys())[:5]  # first 5 found peptide pairs
     peptide_pairs_should = [
@@ -157,6 +157,136 @@ def test9():
         crosslinker="DSS",
     )
     peptide_pairs = filter_peptide_pair_distribution(
+        result["crosslink-spectrum-matches"], prefix_decoys=False
+    )
+    assert len(peptide_pairs) == len(aggregate(result["crosslink-spectrum-matches"]))
+
+
+def test10():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_peptide_pair_distribution
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    peptide_pairs = filter_peptide_pair_distribution(
+        result["crosslink-spectrum-matches"]
+    )
+    peptide_pairs_found = list(peptide_pairs.keys())[:5]  # first 5 found peptide pairs
+    peptide_pairs_should = [
+        "GQKNSR3-GQKNSR3",
+        "GQKNSR3-DECOY_GSQKDR4",
+        "SDKNR3-SDKNR3",
+        "DKQSGK2-DKQSGK2",
+        "DKQSGK2-HSIKK4",
+    ]
+    for p in peptide_pairs_should:
+        assert p in peptide_pairs_found
+    MTNFDKNLPNEK_SKLVSDFR = len(
+        peptide_pairs["MTNFDKNLPNEK6-SKLVSDFR2"]
+    )  # number of CSMs for peptide pair MTNFDKNLPNEK-SKLVSDFR
+    assert MTNFDKNLPNEK_SKLVSDFR == 21
+
+
+def test11():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_peptide_pair_distribution
+    from pyXLMS.transform import aggregate
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    peptide_pairs = filter_peptide_pair_distribution(
         result["crosslink-spectrum-matches"]
     )
     assert len(peptide_pairs) == len(aggregate(result["crosslink-spectrum-matches"]))
+
+
+def test12():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    residue_pairs = filter_residue_pair_distribution(
+        result["crosslink-spectrum-matches"]
+    )
+    residue_pairs_found = list(residue_pairs.keys())[:5]
+    residue_pairs_should = [
+        "Cas9:779-Cas9:779",
+        "Cas9:779-DECOY_Cas9:696",
+        "Cas9:866-Cas9:866",
+        "Cas9:677-Cas9:677",
+        "Cas9:48-Cas9:677",
+    ]
+    for r in residue_pairs_should:
+        assert r in residue_pairs_found
+    assert len(residue_pairs["Cas9:1122-Cas9:884"]) == 22
+
+
+def test13():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+    from pyXLMS.transform import aggregate
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    residue_pairs = filter_residue_pair_distribution(
+        result["crosslink-spectrum-matches"]
+    )
+    assert len(residue_pairs) == len(
+        aggregate(result["crosslink-spectrum-matches"], by="protein")
+    )
+
+
+def test14():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    residue_pairs = filter_residue_pair_distribution(
+        result["crosslink-spectrum-matches"], prefix_decoys=False
+    )
+    residue_pairs_found = list(residue_pairs.keys())[:5]
+    residue_pairs_should = [
+        "Cas9:779-Cas9:779",
+        "Cas9:696-Cas9:779",
+        "Cas9:866-Cas9:866",
+        "Cas9:677-Cas9:677",
+        "Cas9:48-Cas9:677",
+    ]
+    for r in residue_pairs_should:
+        assert r in residue_pairs_found
+    assert len(residue_pairs["Cas9:1122-Cas9:884"]) == 22
+
+
+def test15():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+    from pyXLMS.transform import aggregate
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    residue_pairs = filter_residue_pair_distribution(
+        result["crosslink-spectrum-matches"], prefix_decoys=False
+    )
+    assert len(residue_pairs) == len(
+        aggregate(result["crosslink-spectrum-matches"], by="protein")
+    )

--- a/tests/test_transform_filter.py
+++ b/tests/test_transform_filter.py
@@ -5,6 +5,8 @@
 # https://github.com/michabirklbauer/
 # micha.birklbauer@gmail.com
 
+import pytest
+
 
 def test1():
     from pyXLMS.parser import read
@@ -290,3 +292,79 @@ def test15():
     assert len(residue_pairs) == len(
         aggregate(result["crosslink-spectrum-matches"], by="protein")
     )
+
+
+def test16():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    result["crosslink-spectrum-matches"][0]["completeness"] = "partial"
+    result["crosslink-spectrum-matches"][0]["alpha_proteins"] = None
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Can't filter by residue pair because not all necessary information is available!",
+    ):
+        _ = filter_residue_pair_distribution(result["crosslink-spectrum-matches"])
+
+
+def test17():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    result["crosslink-spectrum-matches"][0]["completeness"] = "partial"
+    result["crosslink-spectrum-matches"][0]["beta_proteins"] = None
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Can't filter by residue pair because not all necessary information is available!",
+    ):
+        _ = filter_residue_pair_distribution(result["crosslink-spectrum-matches"])
+
+
+def test18():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    result["crosslink-spectrum-matches"][0]["completeness"] = "partial"
+    result["crosslink-spectrum-matches"][0]["alpha_proteins_crosslink_positions"] = None
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Can't filter by residue pair because not all necessary information is available!",
+    ):
+        _ = filter_residue_pair_distribution(result["crosslink-spectrum-matches"])
+
+
+def test19():
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    result["crosslink-spectrum-matches"][0]["completeness"] = "partial"
+    result["crosslink-spectrum-matches"][0]["beta_proteins_crosslink_positions"] = None
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Can't filter by residue pair because not all necessary information is available!",
+    ):
+        _ = filter_residue_pair_distribution(result["crosslink-spectrum-matches"])

--- a/tests/test_transform_filter.py
+++ b/tests/test_transform_filter.py
@@ -368,3 +368,22 @@ def test19():
         match=r"Can't filter by residue pair because not all necessary information is available!",
     ):
         _ = filter_residue_pair_distribution(result["crosslink-spectrum-matches"])
+
+
+def test20():
+    # this is technically test for transform.util.get_available_keys for @param always_revalidate
+    from pyXLMS.parser import read
+    from pyXLMS.transform import filter_residue_pair_distribution
+
+    result = read(
+        "data/ms_annika/XLpeplib_Beveridge_QEx-HFX_DSS_R1_CSMs.xlsx",
+        engine="MS Annika",
+        crosslinker="DSS",
+    )
+    result["crosslink-spectrum-matches"][0]["beta_proteins_crosslink_positions"] = None
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Can't filter by residue pair because not all necessary information is available!",
+    ):
+        _ = filter_residue_pair_distribution(result["crosslink-spectrum-matches"])

--- a/tests/test_transform_filter.py
+++ b/tests/test_transform_filter.py
@@ -132,16 +132,16 @@ def test8():
     )
     peptide_pairs_found = list(peptide_pairs.keys())[:5]  # first 5 found peptide pairs
     peptide_pairs_should = [
-        "GQKNSR3-GQKNSR3",
-        "GQKNSR3-GSQKDR4",
-        "SDKNR3-SDKNR3",
-        "DKQSGK2-DKQSGK2",
-        "DKQSGK2-HSIKK4",
+        "GQKNSR:3-GQKNSR:3",
+        "GQKNSR:3-GSQKDR:4",
+        "SDKNR:3-SDKNR:3",
+        "DKQSGK:2-DKQSGK:2",
+        "DKQSGK:2-HSIKK:4",
     ]
     for p in peptide_pairs_should:
         assert p in peptide_pairs_found
     MTNFDKNLPNEK_SKLVSDFR = len(
-        peptide_pairs["MTNFDKNLPNEK6-SKLVSDFR2"]
+        peptide_pairs["MTNFDKNLPNEK:6-SKLVSDFR:2"]
     )  # number of CSMs for peptide pair MTNFDKNLPNEK-SKLVSDFR
     assert MTNFDKNLPNEK_SKLVSDFR == 21
 
@@ -176,16 +176,16 @@ def test10():
     )
     peptide_pairs_found = list(peptide_pairs.keys())[:5]  # first 5 found peptide pairs
     peptide_pairs_should = [
-        "GQKNSR3-GQKNSR3",
-        "GQKNSR3-DECOY_GSQKDR4",
-        "SDKNR3-SDKNR3",
-        "DKQSGK2-DKQSGK2",
-        "DKQSGK2-HSIKK4",
+        "GQKNSR:3-GQKNSR:3",
+        "GQKNSR:3-DECOY_GSQKDR:4",
+        "SDKNR:3-SDKNR:3",
+        "DKQSGK:2-DKQSGK:2",
+        "DKQSGK:2-HSIKK:4",
     ]
     for p in peptide_pairs_should:
         assert p in peptide_pairs_found
     MTNFDKNLPNEK_SKLVSDFR = len(
-        peptide_pairs["MTNFDKNLPNEK6-SKLVSDFR2"]
+        peptide_pairs["MTNFDKNLPNEK:6-SKLVSDFR:2"]
     )  # number of CSMs for peptide pair MTNFDKNLPNEK-SKLVSDFR
     assert MTNFDKNLPNEK_SKLVSDFR == 21
 

--- a/tests/test_transform_filter.py
+++ b/tests/test_transform_filter.py
@@ -132,16 +132,16 @@ def test8():
     )
     peptide_pairs_found = list(peptide_pairs.keys())[:5]  # first 5 found peptide pairs
     peptide_pairs_should = [
-        "GQKNSR-GQKNSR",
-        "GQKNSR-GSQKDR",
-        "SDKNR-SDKNR",
-        "DKQSGK-DKQSGK",
-        "DKQSGK-HSIKK",
+        "GQKNSR3-GQKNSR3",
+        "GQKNSR3-GSQKDR4",
+        "SDKNR3-SDKNR3",
+        "DKQSGK2-DKQSGK2",
+        "DKQSGK2-HSIKK4",
     ]
     for p in peptide_pairs_should:
         assert p in peptide_pairs_found
     MTNFDKNLPNEK_SKLVSDFR = len(
-        peptide_pairs["MTNFDKNLPNEK-SKLVSDFR"]
+        peptide_pairs["MTNFDKNLPNEK6-SKLVSDFR2"]
     )  # number of CSMs for peptide pair MTNFDKNLPNEK-SKLVSDFR
     assert MTNFDKNLPNEK_SKLVSDFR == 21
 


### PR DESCRIPTION
- Updated peptide pair distribution filter to also use peptide crosslink position
- Updated peptide pair distribution filter with a `prefix_decoys` parameter to automatically prefix decoy peptides with a "DECOY_" string for better visibility (this is optional but by default on)
- Added a new residue pair distribution filter analogous to the peptide pair distribution filter
- Added a new residue pair distribution plot analogous to the peptide pair distribution plot