### PR TITLE
Feat/Support for **kwargs in parser.read*

### DIFF
--- a/.github/workflows/pytest-dev.yml
+++ b/.github/workflows/pytest-dev.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/pytest-gui.yml
+++ b/.github/workflows/pytest-gui.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.12', '3.13', '3.14']
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,3 +42,4 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -c pytest.ini --durations=10 --durations-min=1.0 --runslow tests/
+        pytest -c pytest.ini --durations=10 --durations-min=1.0 --runslow --runext tests/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v5
@@ -41,5 +42,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest -c pytest.ini --durations=10 --durations-min=1.0 --runslow tests/
         pytest -c pytest.ini --durations=10 --durations-min=1.0 --runslow --runext tests/

--- a/.github/workflows/test-debug.yml
+++ b/.github/workflows/test-debug.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyXLMS"
-version = "1.8.6"
+version = "1.8.7"
 authors = [
   { name="Micha Johannes Birklbauer", email="micha.birklbauer@fh-hagenberg.at" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ streamlit
 xlsxwriter
 pyarrow
 lxml
+requests

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -15,7 +15,7 @@ project = "pyXLMS"
 copyright = "2025, Bioinformatics Research Group, FH Oberösterreich Campus Hagenberg"
 author = "Micha Johannes Birklbauer"
 version = "1.8"
-release = "1.8.6"
+release = "1.8.7"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/pyXLMS/__init__.py
+++ b/src/pyXLMS/__init__.py
@@ -13,7 +13,7 @@ __all__ = [
     "transform",
     "plotting",
 ]
-__version__ = "1.8.6"
+__version__ = "1.8.7"
 __author__ = "Micha Johannes Birklbauer"
 
 from . import constants

--- a/src/pyXLMS/parser/parser_xldbse_custom.py
+++ b/src/pyXLMS/parser/parser_xldbse_custom.py
@@ -123,6 +123,7 @@ def read_custom(
     format: Literal["auto", "csv", "txt", "tsv", "parquet", "xlsx"] = "auto",
     sep: str = ",",
     decimal: str = ".",
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a custom or pyXLMS result file.
 
@@ -169,6 +170,8 @@ def read_custom(
         Seperator used in the ``.csv`` or ``.tsv`` file. Parameter is ignored if the file is in ``.xlsx`` format.
     decimal : str, default = "."
         Character to recognize as decimal point. Parameter is ignored if the file is in ``.xlsx`` format.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -274,22 +277,26 @@ def read_custom(
                 or file_extension == ".tsv"
                 or file_extension == ".csv"
             ):
-                data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+                data = pd.read_csv(
+                    input, sep=sep, decimal=decimal, low_memory=False, **kwargs
+                )
             elif file_extension == ".parquet":
-                data = pd.read_parquet(input)
+                data = pd.read_parquet(input, **kwargs)
             elif file_extension == ".xlsx":
-                data = pd.read_excel(input, engine="openpyxl")
+                data = pd.read_excel(input, engine="openpyxl", **kwargs)
             else:
                 raise ValueError(
                     f"Detected file extension {file_extension} is not supported! Input file has to be a valid file with extension '.csv', '.tsv', '.parquet' or '.xlsx'!"
                 )
         elif format in ["csv", "tsv", "txt", "parquet", "xlsx"]:
             if format == "xlsx":
-                data = pd.read_excel(input, engine="openpyxl")
+                data = pd.read_excel(input, engine="openpyxl", **kwargs)
             elif format == "parquet":
-                data = pd.read_parquet(input)
+                data = pd.read_parquet(input, **kwargs)
             else:
-                data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+                data = pd.read_csv(
+                    input, sep=sep, decimal=decimal, low_memory=False, **kwargs
+                )
         else:
             raise ValueError(
                 f"Provided input format {format} is not supported! Input format has to be of type 'csv', 'tsv', 'parquet' or 'xlsx'!"

--- a/src/pyXLMS/parser/parser_xldbse_maxquant.py
+++ b/src/pyXLMS/parser/parser_xldbse_maxquant.py
@@ -142,6 +142,7 @@ def read_maxquant(
     modifications: Dict[str, float] = MODIFICATIONS,
     sep: str = "\t",
     decimal: str = ".",
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a MaxQuant result file.
 
@@ -168,6 +169,8 @@ def read_maxquant(
         Seperator used in the ``.txt`` file.
     decimal : str, default = "."
         Character to recognize as decimal point.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -234,7 +237,7 @@ def read_maxquant(
 
     ## process data
     for input in inputs:
-        data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+        data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False, **kwargs)
         xl = data.dropna(axis=0, subset=["Proteins2"])
         for i, row in tqdm(
             xl.iterrows(), total=xl.shape[0], desc="Reading MaxQuant CSMs..."

--- a/src/pyXLMS/parser/parser_xldbse_maxquant.py
+++ b/src/pyXLMS/parser/parser_xldbse_maxquant.py
@@ -343,6 +343,7 @@ def read_maxlynx(
     modifications: Dict[str, float] = MODIFICATIONS,
     sep: str = "\t",
     decimal: str = ".",
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a MaxLynx result file.
 
@@ -369,6 +370,8 @@ def read_maxlynx(
         Seperator used in the ``.txt`` file.
     decimal : str, default = "."
         Character to recognize as decimal point.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -409,4 +412,5 @@ def read_maxlynx(
         modifications,
         sep,
         decimal,
+        **kwargs,
     )

--- a/src/pyXLMS/parser/parser_xldbse_merox.py
+++ b/src/pyXLMS/parser/parser_xldbse_merox.py
@@ -66,7 +66,7 @@ MEROX_COLNAMES = [
 
 
 def __read_merox_file(
-    file: str | BinaryIO, sep: str = ";", decimal: str = "."
+    file: str | BinaryIO, sep: str = ";", decimal: str = ".", **kwargs
 ) -> pd.DataFrame:
     r"""Helper function to read MeroX files into pandas DataFrames.
 
@@ -81,6 +81,8 @@ def __read_merox_file(
         Seperator used in the ``.csv`` or ``.zhrm`` file.
     decimal : str, default = "."
         Character to recognize as decimal point.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -104,10 +106,11 @@ def __read_merox_file(
                 sep=sep,
                 decimal=decimal,
                 low_memory=False,
+                **kwargs,
             )
     if not isinstance(file, str):
         file.seek(0)
-    return pd.read_csv(file, sep=sep, decimal=decimal, low_memory=False)
+    return pd.read_csv(file, sep=sep, decimal=decimal, low_memory=False, **kwargs)
 
 
 def __get_merox_sequence(
@@ -356,6 +359,7 @@ def read_merox(
     modifications: Dict[str, Dict[str, Any]] = MEROX_MODIFICATION_MAPPING,
     sep: str = ";",
     decimal: str = ".",
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a MeroX result file.
 
@@ -383,6 +387,8 @@ def read_merox(
         Seperator used in the ``.csv`` or ``.zhrm`` file.
     decimal : str, default = "."
         Character to recognize as decimal point.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -458,7 +464,7 @@ def read_merox(
 
     for input in inputs:
         ## reading data
-        data = __read_merox_file(input, sep=sep, decimal=decimal)  # ty: ignore[invalid-argument-type]
+        data = __read_merox_file(input, sep=sep, decimal=decimal, **kwargs)  # ty: ignore[invalid-argument-type]
         for i, row in tqdm(
             data.iterrows(),
             total=data.shape[0],

--- a/src/pyXLMS/parser/parser_xldbse_msannika.py
+++ b/src/pyXLMS/parser/parser_xldbse_msannika.py
@@ -148,6 +148,7 @@ def read_msannika(
     decimal: str = ".",
     unsafe: bool = False,
     verbose: Literal[0, 1, 2] = 1,
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read an MS Annika result file.
 
@@ -177,6 +178,8 @@ def read_msannika(
         - 0: All warnings are ignored.
         - 1: Warnings are printed to stdout.
         - 2: Warnings are treated as errors.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -306,10 +309,12 @@ def read_msannika(
                 or file_extension == ".csv"
             ):
                 data_objects = [
-                    pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+                    pd.read_csv(
+                        input, sep=sep, decimal=decimal, low_memory=False, **kwargs
+                    )
                 ]
             elif file_extension == ".xlsx":
-                data_objects = [pd.read_excel(input, engine="openpyxl")]
+                data_objects = [pd.read_excel(input, engine="openpyxl", **kwargs)]
             elif file_extension == ".pdresult":
                 data_objects = __read_msannika_pdresult(input)
             else:
@@ -318,10 +323,12 @@ def read_msannika(
                 )
         elif format in ["csv", "tsv", "txt", "xlsx"]:
             if format == "xlsx":
-                data_objects = [pd.read_excel(input, engine="openpyxl")]
+                data_objects = [pd.read_excel(input, engine="openpyxl", **kwargs)]
             else:
                 data_objects = [
-                    pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+                    pd.read_csv(
+                        input, sep=sep, decimal=decimal, low_memory=False, **kwargs
+                    )
                 ]
         elif format == "pdresult":
             if not isinstance(input, str):

--- a/src/pyXLMS/parser/parser_xldbse_plink.py
+++ b/src/pyXLMS/parser/parser_xldbse_plink.py
@@ -257,6 +257,7 @@ def __read_plink_cross_linked_peptides_file(
             parsed_lines = f.readlines()
             f.close()
     else:
+        file.seek(0)
         parsed_lines = file.readlines()
         file.seek(0)
     if parsed_lines is None:
@@ -391,6 +392,7 @@ def detect_plink_filetype(
             parsed_lines = f.readlines()
             f.close()
     else:
+        file.seek(0)
         parsed_lines = file.readlines()
         file.seek(0)
     if parsed_lines is None:

--- a/src/pyXLMS/parser/parser_xldbse_plink.py
+++ b/src/pyXLMS/parser/parser_xldbse_plink.py
@@ -573,9 +573,9 @@ def read_plink(
     ## process data
     for input in inputs:
         if (
-            detect_plink_filetype(input, sep=sep, decimal=decimal, **kwargs)
+            detect_plink_filetype(input, sep=sep, decimal=decimal, **kwargs)  # ty: ignore[invalid-argument-type]
             == "crosslinks"
-        ):  # ty: ignore[invalid-argument-type]
+        ):
             data = __read_plink_cross_linked_peptides_file(
                 input,  # ty: ignore[invalid-argument-type]
                 sep=sep,

--- a/src/pyXLMS/parser/parser_xldbse_plink.py
+++ b/src/pyXLMS/parser/parser_xldbse_plink.py
@@ -217,7 +217,7 @@ def __parse_proteins_and_position_from_plink(
 
 
 def __read_plink_cross_linked_peptides_file(
-    file: str | BinaryIO, sep: str = ",", decimal: str = "."
+    file: str | BinaryIO, sep: str = ",", decimal: str = ".", **kwargs
 ) -> pd.DataFrame:
     r"""Reads a pLink cross-linked peptides file into a pandas DataFrame.
 
@@ -232,6 +232,8 @@ def __read_plink_cross_linked_peptides_file(
         Seperator used in the ``.csv`` file.
     decimal : str, default = "."
         Character to recognize as decimal point.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -265,7 +267,11 @@ def __read_plink_cross_linked_peptides_file(
         if not preprocessed_line.startswith(sep):
             lines.append(preprocessed_line)
     df = pd.read_csv(
-        io.StringIO("\n".join(lines)), sep=sep, decimal=decimal, low_memory=False
+        io.StringIO("\n".join(lines)),
+        sep=sep,
+        decimal=decimal,
+        low_memory=False,
+        **kwargs,
     )
     colnames = df.columns.values.tolist()
     if not (
@@ -331,7 +337,7 @@ def parse_scan_nr_from_plink(title: str) -> int:
 
 
 def detect_plink_filetype(
-    file: str | BinaryIO, sep: str = ",", decimal: str = "."
+    file: str | BinaryIO, sep: str = ",", decimal: str = ".", **kwargs
 ) -> Literal["crosslinks", "crosslink-spectrum-matches"]:
     r"""Detects the pLink-related file type of the data.
 
@@ -346,6 +352,8 @@ def detect_plink_filetype(
         Seperator used in the ``.csv`` file.
     decimal : str, default = "."
         Character to recognize as decimal point.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -396,7 +404,7 @@ def detect_plink_filetype(
     if len(lines) == 0:
         raise RuntimeError("The provided file does not contain any data!")
     if len(lines) == 1:
-        df = pd.read_csv(file, sep=sep, decimal=decimal, low_memory=False)
+        df = pd.read_csv(file, sep=sep, decimal=decimal, low_memory=False, **kwargs)
         if not isinstance(file, str):
             file.seek(0)
         colnames = df.columns.values.tolist()
@@ -418,9 +426,11 @@ def detect_plink_filetype(
                 "The provided file seems not to be one of the support pLink input files!"
             )
     if lines[1].startswith(sep):
-        _ = __read_plink_cross_linked_peptides_file(file, sep=sep, decimal=decimal)
+        _ = __read_plink_cross_linked_peptides_file(
+            file, sep=sep, decimal=decimal, **kwargs
+        )
         return "crosslinks"
-    df = pd.read_csv(file, sep=sep, decimal=decimal, low_memory=False)
+    df = pd.read_csv(file, sep=sep, decimal=decimal, low_memory=False, **kwargs)
     if not isinstance(file, str):
         file.seek(0)
     colnames = df.columns.values.tolist()
@@ -452,6 +462,7 @@ def read_plink(
     sep: str = ",",
     decimal: str = ".",
     verbose: Literal[0, 1, 2] = 1,
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a pLink result file.
 
@@ -485,6 +496,8 @@ def read_plink(
         - 0: All warnings are ignored.
         - 1: Warnings are printed to stdout.
         - 2: Warnings are treated as errors.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -557,11 +570,15 @@ def read_plink(
 
     ## process data
     for input in inputs:
-        if detect_plink_filetype(input, sep=sep, decimal=decimal) == "crosslinks":  # ty: ignore[invalid-argument-type]
+        if (
+            detect_plink_filetype(input, sep=sep, decimal=decimal, **kwargs)
+            == "crosslinks"
+        ):  # ty: ignore[invalid-argument-type]
             data = __read_plink_cross_linked_peptides_file(
                 input,  # ty: ignore[invalid-argument-type]
                 sep=sep,
                 decimal=decimal,
+                **kwargs,
             )
             for i, row in tqdm(
                 data.iterrows(), total=data.shape[0], desc="Reading pLink crosslinks..."
@@ -601,7 +618,9 @@ def read_plink(
                 )
                 crosslinks.append(crosslink)
         else:
-            data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+            data = pd.read_csv(
+                input, sep=sep, decimal=decimal, low_memory=False, **kwargs
+            )
             for i, row in tqdm(
                 data.iterrows(), total=data.shape[0], desc="Reading pLink CSMs..."
             ):

--- a/src/pyXLMS/parser/parser_xldbse_scout.py
+++ b/src/pyXLMS/parser/parser_xldbse_scout.py
@@ -582,6 +582,7 @@ def read_scout(
     sep: str = ",",
     decimal: str = ".",
     verbose: Literal[0, 1, 2] = 1,
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a Scout result file.
 
@@ -611,6 +612,8 @@ def read_scout(
         - 0: All warnings are ignored.
         - 1: Warnings are printed to stdout.
         - 2: Warnings are treated as errors.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -700,7 +703,7 @@ def read_scout(
 
     for input in inputs:
         ## reading data
-        data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+        data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False, **kwargs)
         ## detect input file type
         scout_file_type = detect_scout_filetype(data)
         ## process data

--- a/src/pyXLMS/parser/parser_xldbse_xi.py
+++ b/src/pyXLMS/parser/parser_xldbse_xi.py
@@ -1060,6 +1060,7 @@ def read_xi(
     decimal: str = ".",
     ignore_errors: bool = False,
     verbose: Literal[0, 1, 2] = 1,
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a xiSearch/xiFDR result file.
 
@@ -1091,6 +1092,8 @@ def read_xi(
         - 0: All warnings are ignored.
         - 1: Warnings are printed to stdout.
         - 2: Warnings are treated as errors.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -1152,7 +1155,7 @@ def read_xi(
 
     for input in inputs:
         ## reading data
-        data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+        data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False, **kwargs)
         ## detect input file type
         xi_file_type = detect_xi_filetype(data)
         ## set decoy prefix

--- a/src/pyXLMS/parser/parser_xldbse_xinet_xiview.py
+++ b/src/pyXLMS/parser/parser_xldbse_xinet_xiview.py
@@ -36,6 +36,7 @@ def read_xinet(
     sep: str = ",",
     decimal: str = ".",
     verbose: Literal[0, 1, 2] = 1,
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a xiNET exported result file.
 
@@ -54,6 +55,8 @@ def read_xinet(
         - 0: All warnings are ignored.
         - 1: Warnings are printed to stdout.
         - 2: Warnings are treated as errors.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -195,7 +198,7 @@ def read_xinet(
 
     ## process data
     for input in inputs:
-        data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+        data = pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False, **kwargs)
         has_csms = "ScanNumber" in data and (
             "run" in data or "RawFileName" in data or "PeakListFileName" in data
         )

--- a/src/pyXLMS/parser/parser_xldbse_xinet_xiview.py
+++ b/src/pyXLMS/parser/parser_xldbse_xinet_xiview.py
@@ -345,6 +345,7 @@ def read_xiview(
     sep: str = ",",
     decimal: str = ".",
     verbose: Literal[0, 1, 2] = 1,
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read a xiVIEW exported result file.
 
@@ -363,6 +364,8 @@ def read_xiview(
         - 0: All warnings are ignored.
         - 1: Warnings are printed to stdout.
         - 2: Warnings are treated as errors.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -402,4 +405,5 @@ def read_xiview(
         sep,
         decimal,
         verbose,
+        **kwargs,
     )

--- a/src/pyXLMS/parser/parser_xldbse_xlinkx.py
+++ b/src/pyXLMS/parser/parser_xldbse_xlinkx.py
@@ -142,6 +142,7 @@ def read_xlinkx(
     decimal: str = ".",
     ignore_errors: bool = False,
     verbose: Literal[0, 1, 2] = 1,
+    **kwargs,
 ) -> Dict[str, Any]:
     r"""Read an XlinkX result file.
 
@@ -174,6 +175,8 @@ def read_xlinkx(
         - 0: All warnings are ignored.
         - 1: Warnings are printed to stdout.
         - 2: Warnings are treated as errors.
+    **kwargs
+        Any additional parameters will be passed to ``pandas.read*``.
 
     Returns
     -------
@@ -356,10 +359,12 @@ def read_xlinkx(
                 or file_extension == ".csv"
             ):
                 data_objects = [
-                    pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+                    pd.read_csv(
+                        input, sep=sep, decimal=decimal, low_memory=False, **kwargs
+                    )
                 ]
             elif file_extension == ".xlsx":
-                data_objects = [pd.read_excel(input, engine="openpyxl")]
+                data_objects = [pd.read_excel(input, engine="openpyxl", **kwargs)]
             elif file_extension == ".pdresult":
                 data_objects = __read_xlinkx_pdresult(input)
             else:
@@ -368,10 +373,12 @@ def read_xlinkx(
                 )
         elif format in ["csv", "tsv", "txt", "xlsx"]:
             if format == "xlsx":
-                data_objects = [pd.read_excel(input, engine="openpyxl")]
+                data_objects = [pd.read_excel(input, engine="openpyxl", **kwargs)]
             else:
                 data_objects = [
-                    pd.read_csv(input, sep=sep, decimal=decimal, low_memory=False)
+                    pd.read_csv(
+                        input, sep=sep, decimal=decimal, low_memory=False, **kwargs
+                    )
                 ]
         elif format == "pdresult":
             if not isinstance(input, str):

--- a/src/pyXLMS/plotting/plot_string_score_distribution.py
+++ b/src/pyXLMS/plotting/plot_string_score_distribution.py
@@ -48,6 +48,7 @@ def plot_string_score_distribution(
 
     Plot the STRING score distribution as a barplot or histogram for inter-links of a
     set of crosslink-spectrum-matches or crosslinks.
+    STRING is accessible via `string-db.org <https://string-db.org>`_.
 
     Parameters
     ----------

--- a/src/pyXLMS/transform/annotate_string_scores.py
+++ b/src/pyXLMS/transform/annotate_string_scores.py
@@ -78,6 +78,7 @@ def get_string_ids(
 
     Calls the STRING API to resolve common protein or gene names, synonyms, or UniProt identifiers
     and accession numbers to map them to the identifiers used internally by STRING.
+    STRING is accessible via `string-db.org <https://string-db.org>`_.
 
     Parameters
     ----------
@@ -180,6 +181,7 @@ def get_string_network(
 
     Retrieves the STRING interaction network via the STRING API for the given STRING IDs
     with interactions including the combined score and all the channel specific scores.
+    STRING is accessible via `string-db.org <https://string-db.org>`_.
 
     Parameters
     ----------
@@ -339,6 +341,7 @@ def annotate_string_scores(
 
     Annotates STRING interactions and STRING scores for inter-links based on their associated proteins.
     Takes a list of crosslink-spectrum-matches or crosslinks, or a parser_result as input.
+    STRING is accessible via `string-db.org <https://string-db.org>`_.
 
     Parameters
     ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,17 +12,31 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="Run (all) slow tests."
     )
+    parser.addoption(
+        "--runext",
+        action="store_true",
+        default=False,
+        help="Run (all) tests relying on external services.",
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line(
+        "markers", "external: mark test as needing external service to run"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
+    if config.getoption("--runslow") and config.getoption("--runext"):
+        # --runslow and --runext given in cli: do not skip tests
         return
     skip_slow = pytest.mark.skip(reason="needs --runslow option to run")
+    skip_ext = pytest.mark.skip(reason="needs --runext option to run")
     for item in items:
         if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+            if not config.getoption("--runslow"):
+                item.add_marker(skip_slow)
+        elif "external" in item.keywords:
+            if not config.getoption("--runext"):
+                item.add_marker(skip_ext)

--- a/tests/test_parser_kwargs.py
+++ b/tests/test_parser_kwargs.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# pyXLMS - TESTS
+# 2026 (c) Micha Johannes Birklbauer
+# https://github.com/michabirklbauer/
+# micha.birklbauer@gmail.com
+
+
+def test1():
+    from pyXLMS.parser import read
+
+    pr = read(
+        "data/_test/annotate_string_scores/Nucleus_Rep1_Crosslinks.txt.xz",
+        engine="MS Annika",
+        crosslinker="DSBSO",
+        format="txt",
+        compression="xz",
+        unsafe=True,
+        verbose=0,
+    )
+    assert pr["crosslinks"] is not None

--- a/tests/test_plotting_plot_string_score_distribution.py
+++ b/tests/test_plotting_plot_string_score_distribution.py
@@ -20,6 +20,7 @@ def cleanup_figures():
     plt.close(fig="all")
 
 
+@pytest.mark.external
 @pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
 def test1():
     from pyXLMS import parser
@@ -32,6 +33,7 @@ def test1():
     assert ax is not None
 
 
+@pytest.mark.external
 @pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
 def test2():
     from pyXLMS import parser
@@ -46,6 +48,7 @@ def test2():
     assert ax is not None
 
 
+@pytest.mark.external
 @pytest.mark.filterwarnings("ignore:'mode' parameter is deprecated")
 def test3():
     from pyXLMS import parser

--- a/tests/test_transform_annotate_string_scores.py
+++ b/tests/test_transform_annotate_string_scores.py
@@ -8,6 +8,7 @@
 import pytest
 
 
+@pytest.mark.external
 def test1():
     from pyXLMS.transform import get_string_network
 
@@ -31,6 +32,7 @@ def test2():
     assert STRING_ORGANISMS["Pseudomonas aeruginosa PAO1"] == 208964
 
 
+@pytest.mark.external
 def test3():
     from pyXLMS.transform import get_string_ids
 
@@ -42,6 +44,7 @@ def test3():
     }
 
 
+@pytest.mark.external
 def test4():
     from pyXLMS.transform import get_string_ids
 
@@ -65,6 +68,7 @@ def test5():
         _ = get_string_ids(["p53", "BRCA1"], organism="s. pyogenes")
 
 
+@pytest.mark.external
 def test6():
     from pyXLMS.transform import get_string_network
 
@@ -86,6 +90,7 @@ def test6():
     }
 
 
+@pytest.mark.external
 def test7():
     from pyXLMS.transform import get_string_network
 
@@ -117,6 +122,7 @@ def test8():
         _ = get_string_network(["p53", "BRCA1"], organism="s. pyogenes")
 
 
+@pytest.mark.external
 def test9():
     from pyXLMS import parser
     from pyXLMS.transform import filter_crosslink_type
@@ -146,6 +152,7 @@ def test9():
     assert example["additional_information"]["pyXLMS_annotated_STRING_score"] == 0.999
 
 
+@pytest.mark.external
 def test10():
     from pyXLMS import parser
     from pyXLMS.transform import filter_crosslink_type
@@ -175,6 +182,7 @@ def test10():
     assert example["additional_information"]["pyXLMS_annotated_STRING_score"] == 0.999
 
 
+@pytest.mark.external
 def test11():
     from pyXLMS import parser
     from pyXLMS.transform import filter_crosslink_type
@@ -189,6 +197,7 @@ def test11():
         assert "pyXLMS_annotated_STRING_score" in item["additional_information"]
 
 
+@pytest.mark.external
 def test12():
     from pyXLMS import parser
     from pyXLMS.transform import filter_crosslink_type
@@ -215,6 +224,7 @@ def test13():
         _ = annotate_string_scores(["p53", "BRCA1"], organism="s. pyogenes")
 
 
+@pytest.mark.external
 def test14():
     from pyXLMS import parser
     from pyXLMS.transform import annotate_string_scores
@@ -258,6 +268,7 @@ def test16():
         _ = annotate_string_scores(intra, organism="Homo sapiens")
 
 
+@pytest.mark.external
 def test17():
     from pyXLMS import parser
     from pyXLMS.transform import annotate_string_scores


### PR DESCRIPTION
- Adds support to pass `**kwargs` to all parser `read` methods to e.g. support reading of compressed files
- Internally all `**kwargs` are passed to `pandas.read*`
- See #220 
