### PR TITLE
fix(parser): robustly extract scan number from mzIdentML spectrumID (#233)

### DIFF
--- a/src/pyXLMS/parser/parser_xldbse_mzid.py
+++ b/src/pyXLMS/parser/parser_xldbse_mzid.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import re
 import warnings
 from tqdm import tqdm
 from pyteomics import mzid
@@ -59,19 +60,28 @@ def parse_scan_nr_from_mzid(spectrum_id: str) -> int:
     >>> from pyXLMS.parser import parse_scan_nr_from_mzid
     >>> parse_scan_nr_from_mzid("index=1")
     RuntimeWarning: Could not parse scan number from spectrum - using index instead!
-    Exception while parsing scan number: list index out of range
+    Exception while parsing scan number: 'scan=' not found in spectrumID
     1
     """
-    try:
-        return __parse_int(str(spectrum_id).split("scan=")[1].split(",")[0])
-    except Exception as e:
-        warnings.warn(
-            RuntimeWarning(
-                "Could not parse scan number from spectrum - using index instead!\n"
-                f"Exception while parsing scan number: {e}"
-            )
+    spectrum_id_str = str(spectrum_id)
+    scan_match = re.search(r"scan=(\d+)", spectrum_id_str)
+    if scan_match is not None:
+        return __parse_int(scan_match.group(1))
+    warnings.warn(
+        RuntimeWarning(
+            "Could not parse scan number from spectrum - using index instead!\n"
+            "Exception while parsing scan number: 'scan=' not found in spectrumID"
         )
-    return __parse_int(str(spectrum_id).split("index=")[1].split(",")[0])
+    )
+    index_match = re.search(r"index=(\d+)", spectrum_id_str)
+    if index_match is not None:
+        return __parse_int(index_match.group(1))
+    fallback_match = re.search(r"(\d+)", spectrum_id_str)
+    if fallback_match is not None:
+        return __parse_int(fallback_match.group(1))
+    raise ValueError(
+        f"Could not parse scan number or index from spectrumID: {spectrum_id_str!r}"
+    )
 
 
 def read_mzid(

--- a/tests/test_parser_xldbse_mzid.py
+++ b/tests/test_parser_xldbse_mzid.py
@@ -55,6 +55,30 @@ def test4():
         assert parse_scan_nr_from_mzid("index=1") == 1
 
 
+def test_parse_scan_nr_thermo_native_id():
+    from pyXLMS.parser import parse_scan_nr_from_mzid
+
+    assert parse_scan_nr_from_mzid("controllerType=0 controllerNumber=1 scan=5321") == 5321
+
+
+def test_parse_scan_nr_hupo_psi_no_scan_no_index():
+    # Regression: HUPO-PSI mzIdentML crosslinking example files use spectrumIDs
+    # that contain neither 'scan=' nor 'index=' (issue #233). The parser must
+    # not raise IndexError; it must fall back to any embedded integer.
+    from pyXLMS.parser import parse_scan_nr_from_mzid
+
+    with pytest.warns(RuntimeWarning):
+        assert parse_scan_nr_from_mzid("spectrum=10") == 10
+
+
+def test_parse_scan_nr_no_digits_raises_value_error():
+    from pyXLMS.parser import parse_scan_nr_from_mzid
+
+    with pytest.warns(RuntimeWarning):
+        with pytest.raises(ValueError):
+            parse_scan_nr_from_mzid("opaque-id")
+
+
 def test5():
     from pyteomics import mzid
     from pyXLMS import parser as p


### PR DESCRIPTION
Fixes #233.

`parse_scan_nr_from_mzid` did `split("scan=")[1]` then fell back to `split("index=")[1]`. The HUPO-PSI official mzIdentML crosslinking example files use spectrumIDs that contain neither token, so both calls raised `IndexError: list index out of range` and aborted the import.

Switch to `re.search(r"scan=(\d+)")` then `re.search(r"index=(\d+)")`, with a final fallback that extracts the first integer found anywhere in the spectrumID. If no digits exist at all, raise `ValueError` with the offending spectrumID instead of `IndexError`.

Also handles the Thermo `controllerType=0 controllerNumber=1 scan=N` native ID format, which the old split-based parser handled correctly but wasn't covered by tests.

Regression tests added for the HUPO-PSI no-scan-no-index case, the Thermo native ID case, and the no-digit-at-all error path.