### PR TITLE
Fix/Import `typing.Annotated` from `typing_extensions` for python < 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyXLMS"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
   { name="Micha Johannes Birklbauer", email="micha.birklbauer@fh-hagenberg.at" },
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -15,7 +15,7 @@ project = "pyXLMS"
 copyright = "2026, Bioinformatics Research Group, FH Oberösterreich Campus Hagenberg"
 author = "Micha Johannes Birklbauer"
 version = "2.0"
-release = "2.0.1"
+release = "2.0.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/pyXLMS/__init__.py
+++ b/src/pyXLMS/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     "transform",
     "plotting",
 ]
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __author__ = "Micha Johannes Birklbauer"
 
 from . import constants

--- a/src/pyXLMS/data/_crosslink.py
+++ b/src/pyXLMS/data/_crosslink.py
@@ -18,7 +18,6 @@ from ._util import check_input
 from ._util import check_indexing
 from ._util import __get_modified_peptide as get_modified_peptide
 
-from typing import Annotated
 from typing import Optional
 from typing import List
 from typing import Dict
@@ -30,6 +29,10 @@ if sys.version_info > (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+if sys.version_info > (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 if sys.version_info > (3, 12):
     from typing import override
 else:

--- a/src/pyXLMS/data/_csm.py
+++ b/src/pyXLMS/data/_csm.py
@@ -20,7 +20,6 @@ from ._util import check_input
 from ._util import check_indexing
 from ._util import __get_modified_peptide as get_modified_peptide
 
-from typing import Annotated
 from typing import Optional
 from typing import List
 from typing import Dict
@@ -32,6 +31,10 @@ if sys.version_info > (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+if sys.version_info > (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 if sys.version_info > (3, 12):
     from typing import override
 else:

--- a/src/pyXLMS/data/_parser_result.py
+++ b/src/pyXLMS/data/_parser_result.py
@@ -17,7 +17,6 @@ from ._csm import CrosslinkSpectrumMatch
 from ._crosslink import Crosslink
 from ._util import check_input
 
-from typing import Annotated
 from typing import Optional
 from typing import List
 from typing import Dict
@@ -29,6 +28,10 @@ if sys.version_info > (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+if sys.version_info > (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 
 class ParserResult(BaseModel):


### PR DESCRIPTION
- Fixes the `typing.Annotated` import for older python versions (3.7, 3.8)
