### PR TITLE
Docs/Fix return type descriptions in the data doc strings

### DIFF
--- a/src/pyXLMS/data/_crosslink.py
+++ b/src/pyXLMS/data/_crosslink.py
@@ -686,8 +686,8 @@ def create_crosslink(
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
+    Crosslink
+        The data structure representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
         ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_decoy``, ``beta_peptide``, ``beta_peptide_crosslink_position``,
         ``beta_proteins``, ``beta_proteins_crosslink_positions``, ``beta_decoy``, ``crosslink_type``, ``score``, and ``additional_information``.
         Alpha and beta are assigned based on peptide sequence, the peptide that alphabetically comes first is assigned to alpha.
@@ -785,8 +785,8 @@ def create_crosslink_min(
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
+    Crosslink
+        The data structure representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
         ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_decoy``, ``beta_peptide``, ``beta_peptide_crosslink_position``,
         ``beta_proteins``, ``beta_proteins_crosslink_positions``, ``beta_decoy``, ``crosslink_type``, ``score``, and ``additional_information``.
         Alpha and beta are assigned based on peptide sequence, the peptide that alphabetically comes first is assigned to alpha.

--- a/src/pyXLMS/data/_csm.py
+++ b/src/pyXLMS/data/_csm.py
@@ -1128,8 +1128,8 @@ def create_csm(
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink-spectrum-match with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_modifications``,
+    CrosslinkSpectrumMatch
+        The data structure representing the crosslink-spectrum-match with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_modifications``,
         ``alpha_peptide_crosslink_position``, ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_proteins_peptide_positions``,
         ``alpha_score``, ``alpha_decoy``, ``beta_peptide``, ``beta_modifications``, ``beta_peptide_crosslink_position``, ``beta_proteins``,
         ``beta_proteins_crosslink_positions``, ``beta_proteins_peptide_positions``, ``beta_score``, ``beta_decoy``, ``crosslink_type``, ``score``,
@@ -1270,8 +1270,8 @@ def create_csm_min(
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink-spectrum-match with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_modifications``,
+    CrosslinkSpectrumMatch
+        The data structure representing the crosslink-spectrum-match with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_modifications``,
         ``alpha_peptide_crosslink_position``, ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_proteins_peptide_positions``,
         ``alpha_score``, ``alpha_decoy``, ``beta_peptide``, ``beta_modifications``, ``beta_peptide_crosslink_position``, ``beta_proteins``,
         ``beta_proteins_crosslink_positions``, ``beta_proteins_peptide_positions``, ``beta_score``, ``beta_decoy``, ``crosslink_type``, ``score``,
@@ -1341,8 +1341,8 @@ def create_crosslink_from_csm(csm: CrosslinkSpectrumMatch) -> Crosslink:
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
+    Crosslink
+        The data structure representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
         ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_decoy``, ``beta_peptide``, ``beta_peptide_crosslink_position``,
         ``beta_proteins``, ``beta_proteins_crosslink_positions``, ``beta_decoy``, ``crosslink_type``, ``score``, and ``additional_information``.
         Alpha and beta are assigned based on peptide sequence, the peptide that alphabetically comes first is assigned to alpha.

--- a/src/pyXLMS/data/_parser_result.py
+++ b/src/pyXLMS/data/_parser_result.py
@@ -370,8 +370,8 @@ def create_parser_result(
 
     Returns
     -------
-    dict
-        The parser result data structure which is a dictionary with keys ``data_type``, ``completeness``, ``search_engine``, ``crosslink-spectrum-matches`` and
+    ParserResult
+        The parser result data structure with keys ``data_type``, ``completeness``, ``search_engine``, ``crosslink-spectrum-matches`` and
         ``crosslinks``.
 
     Examples


### PR DESCRIPTION
- Fixed the return types in the documentation for several functions in `pyXLMS.data` that were not yet updated since the release of pyXLMS 2.0
