### PR TITLE
Fix/Allow xiFDR export even if no decoys are found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyXLMS"
-version = "2.0.2"
+version = "2.0.3"
 authors = [
   { name="Micha Johannes Birklbauer", email="micha.birklbauer@fh-hagenberg.at" },
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -15,7 +15,7 @@ project = "pyXLMS"
 copyright = "2026, Bioinformatics Research Group, FH Oberösterreich Campus Hagenberg"
 author = "Micha Johannes Birklbauer"
 version = "2.0"
-release = "2.0.2"
+release = "2.0.3"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/pyXLMS/__init__.py
+++ b/src/pyXLMS/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     "transform",
     "plotting",
 ]
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __author__ = "Micha Johannes Birklbauer"
 
 from . import constants

--- a/src/pyXLMS/exporter/_to_xifdr.py
+++ b/src/pyXLMS/exporter/_to_xifdr.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import warnings
 import pandas as pd
 
 from ..data._csm import CrosslinkSpectrumMatch
@@ -185,7 +186,17 @@ def to_xifdr(
         csms,
     )
     if len(filter_target_decoy(csms)["Target-Decoy"]) == 0:
-        raise RuntimeError(
-            "Can't export to xiFDR because number of target-decoy matches is zero!"
+        warnings.warn(
+            RuntimeWarning(
+                "Number of target-decoy matches is zero!",
+            ),
+            stacklevel=2,
+        )
+    if len(filter_target_decoy(csms)["Decoy-Decoy"]) == 0:
+        warnings.warn(
+            RuntimeWarning(
+                "Number of decoy-decoy matches is zero!",
+            ),
+            stacklevel=2,
         )
     return __csms_to_xifdr(csms, filename)

--- a/src/pyXLMS/exporter/_to_xifdr.py
+++ b/src/pyXLMS/exporter/_to_xifdr.py
@@ -133,6 +133,11 @@ def to_xifdr(
     RuntimeError
         If not all of the required information is present in the input data.
 
+    Warns
+    -----
+    RuntimeWarning
+        If the number of decoy-decoy or target-decoy matches is zero.
+
     Examples
     --------
     >>> from pyXLMS.exporter import to_xifdr

--- a/src/pyXLMS/transform/_filter.py
+++ b/src/pyXLMS/transform/_filter.py
@@ -96,7 +96,7 @@ def filter_target_decoy(
                 tt.append(item)
             else:
                 td.append(item)
-    return {"Target-Target": tt, "Target-Decoy": td, "Decoy-Decoy": dd}
+    return {"Target-Target": tt, "Target-Decoy": td, "Decoy-Decoy": dd}  # ty: ignore[invalid-return-type]
 
 
 def filter_proteins(
@@ -189,7 +189,7 @@ def filter_proteins(
                 continue
             else:
                 inter.append(item)
-    return {"Proteins": list(proteins), "Both": intra, "One": inter}
+    return {"Proteins": list(proteins), "Both": intra, "One": inter}  # ty: ignore[invalid-return-type]
 
 
 def filter_protein_distribution(
@@ -251,7 +251,7 @@ def filter_protein_distribution(
                     proteins[protein].append(item)
                 else:
                     proteins[protein] = [item]
-    return proteins
+    return proteins  # ty: ignore[invalid-return-type]
 
 
 def filter_crosslink_type(
@@ -318,7 +318,7 @@ def filter_crosslink_type(
             intra.append(item)
         else:
             inter.append(item)
-    return {"Intra": intra, "Inter": inter}
+    return {"Intra": intra, "Inter": inter}  # ty: ignore[invalid-return-type]
 
 
 def filter_peptide_pair_distribution(

--- a/src/pyXLMS/transform/_reannotate_positions.py
+++ b/src/pyXLMS/transform/_reannotate_positions.py
@@ -318,7 +318,7 @@ def reannotate_positions(
                 f"Can't annotate positions for data type {type(data[0])}. Valid data types are:\n"
                 "'crosslink-spectrum-match', 'crosslink', and 'parser_result'."
             )
-        return reannoted
+        return reannoted  # ty: ignore[invalid-return-type]
     new_csms = (
         assert_csms(
             reannotate_positions(

--- a/src/pyXLMS/transform/_validate.py
+++ b/src/pyXLMS/transform/_validate.py
@@ -167,7 +167,7 @@ def __validate_strict(
         else:
             # do nothing
             pass
-    return validated_items
+    return validated_items  # ty: ignore[invalid-return-type]
 
 
 def __verify_fdr_relaxed(
@@ -339,7 +339,7 @@ def __validate_relaxed(
         else:
             # do nothing
             pass
-    return validated_items
+    return validated_items  # ty: ignore[invalid-return-type]
 
 
 def validate(


### PR DESCRIPTION
- If no decoy CSMs are found the xiFDR exporter will now raise a warning instead of an error