### PR TITLE
V2.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyXLMS"
-version = "2.0.2"
+version = "2.0.3"
 authors = [
   { name="Micha Johannes Birklbauer", email="micha.birklbauer@fh-hagenberg.at" },
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -37,9 +37,12 @@ target-version = "py37"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-select = ["E4", "E7", "E9", "F"]
-extend-select = ["S", "B", "A", "Q", "N", "D1", "PD", "UP", "RUF1"]
+# select = ["E4", "E7", "E9", "F"]
+select = ["E", "W", "F"]
+extend-select = ["S", "B", "A", "Q", "N", "D1", "PD", "UP", "EXE", "FIX", "FA102", "RUF1"]
 # Ignore the following rules:
+# - E501: line-too-long
+#   Line too long
 # - B006: mutable-argument-default
 #   Do not use mutable data structures for argument defaults
 # - UP006: non-pep585-annotation
@@ -48,7 +51,7 @@ extend-select = ["S", "B", "A", "Q", "N", "D1", "PD", "UP", "RUF1"]
 #   Unnecessary mode argument
 # - UP045: non-pep604-annotation-optional
 #   Use X | None for type annotations
-ignore = ["B006", "UP006", "UP015", "UP045"]
+ignore = ["E501", "B006", "UP006", "UP015", "UP045"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -51,7 +51,11 @@ extend-select = ["S", "B", "A", "Q", "N", "D1", "PD", "UP", "EXE", "FIX", "FA102
 #   Unnecessary mode argument
 # - UP045: non-pep604-annotation-optional
 #   Use X | None for type annotations
-ignore = ["E501", "B006", "UP006", "UP015", "UP045"]
+# - EXE001: shebang-not-executable
+#   Shebang is present but file is not executable (Unix only)
+# - EXE002: shebang-missing-executable-file
+#   The file is executable but no shebang is present (Unix only)
+ignore = ["E501", "B006", "UP006", "UP015", "UP045", "EXE001", "EXE002"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -15,7 +15,7 @@ project = "pyXLMS"
 copyright = "2026, Bioinformatics Research Group, FH Oberösterreich Campus Hagenberg"
 author = "Micha Johannes Birklbauer"
 version = "2.0"
-release = "2.0.2"
+release = "2.0.3"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/pyXLMS/__init__.py
+++ b/src/pyXLMS/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     "transform",
     "plotting",
 ]
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __author__ = "Micha Johannes Birklbauer"
 
 from . import constants

--- a/src/pyXLMS/data/_crosslink.py
+++ b/src/pyXLMS/data/_crosslink.py
@@ -686,8 +686,8 @@ def create_crosslink(
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
+    Crosslink
+        The data structure representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
         ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_decoy``, ``beta_peptide``, ``beta_peptide_crosslink_position``,
         ``beta_proteins``, ``beta_proteins_crosslink_positions``, ``beta_decoy``, ``crosslink_type``, ``score``, and ``additional_information``.
         Alpha and beta are assigned based on peptide sequence, the peptide that alphabetically comes first is assigned to alpha.
@@ -785,8 +785,8 @@ def create_crosslink_min(
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
+    Crosslink
+        The data structure representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
         ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_decoy``, ``beta_peptide``, ``beta_peptide_crosslink_position``,
         ``beta_proteins``, ``beta_proteins_crosslink_positions``, ``beta_decoy``, ``crosslink_type``, ``score``, and ``additional_information``.
         Alpha and beta are assigned based on peptide sequence, the peptide that alphabetically comes first is assigned to alpha.

--- a/src/pyXLMS/data/_csm.py
+++ b/src/pyXLMS/data/_csm.py
@@ -1128,8 +1128,8 @@ def create_csm(
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink-spectrum-match with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_modifications``,
+    CrosslinkSpectrumMatch
+        The data structure representing the crosslink-spectrum-match with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_modifications``,
         ``alpha_peptide_crosslink_position``, ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_proteins_peptide_positions``,
         ``alpha_score``, ``alpha_decoy``, ``beta_peptide``, ``beta_modifications``, ``beta_peptide_crosslink_position``, ``beta_proteins``,
         ``beta_proteins_crosslink_positions``, ``beta_proteins_peptide_positions``, ``beta_score``, ``beta_decoy``, ``crosslink_type``, ``score``,
@@ -1270,8 +1270,8 @@ def create_csm_min(
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink-spectrum-match with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_modifications``,
+    CrosslinkSpectrumMatch
+        The data structure representing the crosslink-spectrum-match with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_modifications``,
         ``alpha_peptide_crosslink_position``, ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_proteins_peptide_positions``,
         ``alpha_score``, ``alpha_decoy``, ``beta_peptide``, ``beta_modifications``, ``beta_peptide_crosslink_position``, ``beta_proteins``,
         ``beta_proteins_crosslink_positions``, ``beta_proteins_peptide_positions``, ``beta_score``, ``beta_decoy``, ``crosslink_type``, ``score``,
@@ -1341,8 +1341,8 @@ def create_crosslink_from_csm(csm: CrosslinkSpectrumMatch) -> Crosslink:
 
     Returns
     -------
-    dict
-        The dictionary representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
+    Crosslink
+        The data structure representing the crosslink with keys ``data_type``, ``completeness``, ``alpha_peptide``, ``alpha_peptide_crosslink_position``,
         ``alpha_proteins``, ``alpha_proteins_crosslink_positions``, ``alpha_decoy``, ``beta_peptide``, ``beta_peptide_crosslink_position``,
         ``beta_proteins``, ``beta_proteins_crosslink_positions``, ``beta_decoy``, ``crosslink_type``, ``score``, and ``additional_information``.
         Alpha and beta are assigned based on peptide sequence, the peptide that alphabetically comes first is assigned to alpha.

--- a/src/pyXLMS/data/_parser_result.py
+++ b/src/pyXLMS/data/_parser_result.py
@@ -370,8 +370,8 @@ def create_parser_result(
 
     Returns
     -------
-    dict
-        The parser result data structure which is a dictionary with keys ``data_type``, ``completeness``, ``search_engine``, ``crosslink-spectrum-matches`` and
+    ParserResult
+        The parser result data structure with keys ``data_type``, ``completeness``, ``search_engine``, ``crosslink-spectrum-matches`` and
         ``crosslinks``.
 
     Examples

--- a/src/pyXLMS/exporter/_to_xifdr.py
+++ b/src/pyXLMS/exporter/_to_xifdr.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import warnings
 import pandas as pd
 
 from ..data._csm import CrosslinkSpectrumMatch
@@ -185,7 +186,17 @@ def to_xifdr(
         csms,
     )
     if len(filter_target_decoy(csms)["Target-Decoy"]) == 0:
-        raise RuntimeError(
-            "Can't export to xiFDR because number of target-decoy matches is zero!"
+        warnings.warn(
+            RuntimeWarning(
+                "Number of target-decoy matches is zero!",
+            ),
+            stacklevel=2,
+        )
+    if len(filter_target_decoy(csms)["Decoy-Decoy"]) == 0:
+        warnings.warn(
+            RuntimeWarning(
+                "Number of decoy-decoy matches is zero!",
+            ),
+            stacklevel=2,
         )
     return __csms_to_xifdr(csms, filename)

--- a/src/pyXLMS/exporter/_to_xifdr.py
+++ b/src/pyXLMS/exporter/_to_xifdr.py
@@ -133,6 +133,11 @@ def to_xifdr(
     RuntimeError
         If not all of the required information is present in the input data.
 
+    Warns
+    -----
+    RuntimeWarning
+        If the number of decoy-decoy or target-decoy matches is zero.
+
     Examples
     --------
     >>> from pyXLMS.exporter import to_xifdr

--- a/src/pyXLMS/transform/_filter.py
+++ b/src/pyXLMS/transform/_filter.py
@@ -96,7 +96,7 @@ def filter_target_decoy(
                 tt.append(item)
             else:
                 td.append(item)
-    return {"Target-Target": tt, "Target-Decoy": td, "Decoy-Decoy": dd}
+    return {"Target-Target": tt, "Target-Decoy": td, "Decoy-Decoy": dd}  # ty: ignore[invalid-return-type]
 
 
 def filter_proteins(
@@ -189,7 +189,7 @@ def filter_proteins(
                 continue
             else:
                 inter.append(item)
-    return {"Proteins": list(proteins), "Both": intra, "One": inter}
+    return {"Proteins": list(proteins), "Both": intra, "One": inter}  # ty: ignore[invalid-return-type]
 
 
 def filter_protein_distribution(
@@ -251,7 +251,7 @@ def filter_protein_distribution(
                     proteins[protein].append(item)
                 else:
                     proteins[protein] = [item]
-    return proteins
+    return proteins  # ty: ignore[invalid-return-type]
 
 
 def filter_crosslink_type(
@@ -318,7 +318,7 @@ def filter_crosslink_type(
             intra.append(item)
         else:
             inter.append(item)
-    return {"Intra": intra, "Inter": inter}
+    return {"Intra": intra, "Inter": inter}  # ty: ignore[invalid-return-type]
 
 
 def filter_peptide_pair_distribution(

--- a/src/pyXLMS/transform/_reannotate_positions.py
+++ b/src/pyXLMS/transform/_reannotate_positions.py
@@ -318,7 +318,7 @@ def reannotate_positions(
                 f"Can't annotate positions for data type {type(data[0])}. Valid data types are:\n"
                 "'crosslink-spectrum-match', 'crosslink', and 'parser_result'."
             )
-        return reannoted
+        return reannoted  # ty: ignore[invalid-return-type]
     new_csms = (
         assert_csms(
             reannotate_positions(

--- a/src/pyXLMS/transform/_validate.py
+++ b/src/pyXLMS/transform/_validate.py
@@ -167,7 +167,7 @@ def __validate_strict(
         else:
             # do nothing
             pass
-    return validated_items
+    return validated_items  # ty: ignore[invalid-return-type]
 
 
 def __verify_fdr_relaxed(
@@ -339,7 +339,7 @@ def __validate_relaxed(
         else:
             # do nothing
             pass
-    return validated_items
+    return validated_items  # ty: ignore[invalid-return-type]
 
 
 def validate(


### PR DESCRIPTION
- Fixes return types in some function in the documentation
- Allow export to xiFDR even for CSMs without decoy matches
- Stricter ruff ruleset